### PR TITLE
Remove encoding BOM from rb files

### DIFF
--- a/regression-test/dsda-index.rb
+++ b/regression-test/dsda-index.rb
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env ruby
+#!/usr/bin/env ruby
 # spec/dsda-index.rb
 require_relative "support/dsda-common"
 include DSDA

--- a/regression-test/dsda-reg-test.rb
+++ b/regression-test/dsda-reg-test.rb
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require 'fileutils'

--- a/regression-test/dsda-sync.rb
+++ b/regression-test/dsda-sync.rb
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env ruby
+#!/usr/bin/env ruby
 # spec/dsda-sync.rb
 require_relative "support/dsda-common"
 include DSDA


### PR DESCRIPTION
Not needed, and it is highlighted on certain editors as an outlier UTF8 character.